### PR TITLE
fixes getopt endless loop on Raspberry Pi

### DIFF
--- a/console-qrcode.c
+++ b/console-qrcode.c
@@ -40,7 +40,7 @@ const struct option long_options[] = {
 
 int main(int argc, char **argv) {
 	int longindex;
-	char option;
+	int option;
 	while ((option = getopt_long(argc,argv,short_options,long_options, &longindex)) != -1){
 		switch (option){
 		case 'p':


### PR DESCRIPTION
return type of getopt_long is int, not char. compare with -1 does not work with char (255 != -1)